### PR TITLE
Fix puppeteer

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -11,7 +11,6 @@ export function createBrowserManager (env, logger, retryOperation) {
 
   const puppeteerOptions = {
     args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-web-security'],
-    pipe: true,
     timeout,
   }
 


### PR DESCRIPTION
Hi @ezzatron 

Since early this year, `pipe: true` start to cause ci build error
```
OUTPUT_PATH="artifacts/build/release/site/betusa" node_modules/.bin/iconduit sites/betusa
error: ProtocolError: Protocol error (Target.setDiscoverTargets): Target closed.
    at /runner/_work/branding/branding/node_modules/puppeteer/lib/cjs/puppeteer/common/Connection.js:75:24
    at new Promise (<anonymous>)
    at Connection.send (/runner/_work/branding/branding/node_modules/puppeteer/lib/cjs/puppeteer/common/Connection.js:71:16)
    at Function.create (/runner/_work/branding/branding/node_modules/puppeteer/lib/cjs/puppeteer/common/Browser.js:121:26)
    at ChromeLauncher.launch (/runner/_work/branding/branding/node_modules/puppeteer/lib/cjs/puppeteer/node/Launcher.js:129:50)
    at async run (file:///runner/_work/branding/branding/node_modules/@iconduit/iconduit/src/browser.js:23:17)
    at async buildConfigs (file:///runner/_work/branding/branding/node_modules/@iconduit/iconduit/src/build.js:167:5)
    at async main (file:///runner/_work/branding/branding/node_modules/@iconduit/iconduit/bin/iconduit.js:[13](https://github.cwx.io/pipehat/branding/runs/22685?check_suite_focus=true#step:8:14):3)
make: *** [Makefile:50: artifacts/build/release/site/betusa] Error 1
Error: Process completed with exit code 2.
```

Similar issue is mentioned by https://github.com/puppeteer/puppeteer/issues/6258

So I have tried to update it and test it in `codeworx/branding` which actually fixed CI.

But I might need your help to merge this and tag it. So that we could update it properly

Thanks